### PR TITLE
removed `From<tuple>` implementations for `DrawParam`

### DIFF
--- a/examples/01_super_simple.rs
+++ b/examples/01_super_simple.rs
@@ -40,7 +40,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
             graphics::CanvasLoadOp::Clear([0.1, 0.2, 0.3, 1.0].into()),
         );
 
-        canvas.draw_mesh(self.circle.clone(), None, (Vec2::new(self.pos_x, 380.0),));
+        canvas.draw_mesh(self.circle.clone(), None, Vec2::new(self.pos_x, 380.0));
 
         canvas.finish(&mut ctx.gfx)?;
 

--- a/examples/animation.rs
+++ b/examples/animation.rs
@@ -302,7 +302,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
 
         // draw the animated ball
         let ball_pos = self.ball_animation.now_strict().unwrap();
-        canvas.draw_mesh(self.ball.clone(), None, (ball_pos,));
+        canvas.draw_mesh(self.ball.clone(), None, ball_pos);
 
         // draw the player
         let current_frame_src: graphics::Rect = self.player_animation.now_strict().unwrap().into();

--- a/examples/eventloop.rs
+++ b/examples/eventloop.rs
@@ -78,7 +78,7 @@ pub fn main() -> GameResult {
                     Color::WHITE,
                 )
                 .unwrap();
-                canvas.draw_mesh(circle, None, (glam::Vec2::new(position, 380.0),));
+                canvas.draw_mesh(circle, None, glam::Vec2::new(position, 380.0));
 
                 canvas.finish(&mut ctx.gfx).unwrap();
                 ctx.gfx.end_frame().unwrap();

--- a/examples/graphics_settings.rs
+++ b/examples/graphics_settings.rs
@@ -94,7 +94,10 @@ impl event::EventHandler<ggez::GameError> for MainState {
         canvas.draw_mesh(
             circle,
             None,
-            (Point2::new(400.0, 300.0), rotation as f32, Color::WHITE),
+            DrawParam::new()
+                .dest(Point2::new(400.0, 300.0))
+                .rotation(rotation as f32)
+                .color(Color::WHITE),
         );
 
         // Let's draw a grid so we can see where the window bounds are.
@@ -124,7 +127,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
             }
         }
         let mesh = graphics::Mesh::from_data(&ctx.gfx, mb.build());
-        canvas.draw_mesh(mesh, None, (ggez::mint::Point2 { x: 0.0, y: 0.0 },));
+        canvas.draw_mesh(mesh, None, ggez::mint::Point2 { x: 0.0, y: 0.0 });
 
         canvas.finish(&mut ctx.gfx)?;
 

--- a/examples/hello_canvas.rs
+++ b/examples/hello_canvas.rs
@@ -57,7 +57,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
 
             canvas.draw_text(
                 &[text.color(Color::from((0, 0, 0, 255)))],
-                dest_point - vec2(15., 15.),
+                dest_point + vec2(15., 15.),
                 0.0,
                 graphics::TextLayout::tl_single_line(),
                 0,

--- a/examples/input_test.rs
+++ b/examples/input_test.rs
@@ -53,7 +53,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
             },
             Color::WHITE,
         )?;
-        canvas.draw_mesh(rectangle, None, (glam::Vec2::new(0.0, 0.0),));
+        canvas.draw_mesh(rectangle, None, glam::Vec2::new(0.0, 0.0));
         canvas.finish(&mut ctx.gfx)?;
         Ok(())
     }

--- a/examples/shader.rs
+++ b/examples/shader.rs
@@ -48,7 +48,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
             2.0,
             Color::WHITE,
         )?;
-        canvas.draw_mesh(circle, None, (glam::Vec2::new(0.0, 0.0),));
+        canvas.draw_mesh(circle, None, glam::Vec2::new(0.0, 0.0));
 
         self.params.set_uniforms(&ctx.gfx, &self.dim);
         canvas.set_shader(self.shader.clone());
@@ -61,7 +61,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
             2.0,
             Color::WHITE,
         )?;
-        canvas.draw_mesh(circle, None, (glam::Vec2::new(0.0, 0.0),));
+        canvas.draw_mesh(circle, None, glam::Vec2::new(0.0, 0.0));
 
         canvas.set_default_shader();
         let circle = graphics::Mesh::new_circle(
@@ -72,7 +72,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
             2.0,
             Color::WHITE,
         )?;
-        canvas.draw_mesh(circle, None, (glam::Vec2::new(0.0, 0.0),));
+        canvas.draw_mesh(circle, None, glam::Vec2::new(0.0, 0.0));
 
         canvas.finish(&mut ctx.gfx)
     }

--- a/examples/sounds.rs
+++ b/examples/sounds.rs
@@ -77,8 +77,7 @@ impl event::EventHandler<ggez::GameError> for MainState {
 
         canvas.draw_text(
             &[graphics::Text::new()
-                .text("Press number keys 1-6 to play a sound, or escape to quit.")
-                .font("LiberationMono")],
+                .text("Press number keys 1-6 to play a sound, or escape to quit.")],
             Vec2::new(100.0, 100.0),
             0.0,
             graphics::TextLayout::tl_single_line(),

--- a/examples/transforms.rs
+++ b/examples/transforms.rs
@@ -1,6 +1,6 @@
 //! Demonstrates various projection and matrix fiddling/testing.
 use ggez::event::{self, KeyCode, KeyMods};
-use ggez::graphics::{self, Color, DrawMode};
+use ggez::graphics::{self, Color, DrawMode, DrawParam};
 use ggez::{Context, GameResult};
 use glam::*;
 use std::env;
@@ -88,7 +88,11 @@ impl event::EventHandler<ggez::GameError> for MainState {
         canvas.set_screen_coordinates(self.screen_coords);
 
         let origin = Vec2::ZERO;
-        canvas.draw_mesh(self.gridmesh.clone(), None, (origin, Color::WHITE));
+        canvas.draw_mesh(
+            self.gridmesh.clone(),
+            None,
+            DrawParam::new().dest(origin).color(Color::WHITE),
+        );
 
         let param = graphics::DrawParam::new()
             .dest(Vec2::new(400.0, 400.0))

--- a/src/graphics/draw.rs
+++ b/src/graphics/draw.rs
@@ -244,69 +244,13 @@ impl DrawParam {
     }
 }
 
-/// Create a `DrawParam` from a location.
-/// Note that this takes a single-element tuple.
-/// It's a little weird but keeps the trait implementations
-/// from clashing.
-impl<P> From<(P,)> for DrawParam
+/// Create a `DrawParam` from a location
+impl<P> From<P> for DrawParam
 where
     P: Into<mint::Point2<f32>>,
 {
-    fn from(location: (P,)) -> Self {
-        DrawParam::new().dest(location.0)
-    }
-}
-
-/// Create a `DrawParam` from a location and color
-impl<P> From<(P, Color)> for DrawParam
-where
-    P: Into<mint::Point2<f32>>,
-{
-    fn from((location, color): (P, Color)) -> Self {
-        DrawParam::new().dest(location).color(color)
-    }
-}
-
-/// Create a `DrawParam` from a location, rotation and color
-impl<P> From<(P, f32, Color)> for DrawParam
-where
-    P: Into<mint::Point2<f32>>,
-{
-    fn from((location, rotation, color): (P, f32, Color)) -> Self {
-        DrawParam::new()
-            .dest(location)
-            .rotation(rotation)
-            .color(color)
-    }
-}
-
-/// Create a `DrawParam` from a location, rotation, offset and color
-impl<P> From<(P, f32, P, Color)> for DrawParam
-where
-    P: Into<mint::Point2<f32>>,
-{
-    fn from((location, rotation, offset, color): (P, f32, P, Color)) -> Self {
-        DrawParam::new()
-            .dest(location)
-            .rotation(rotation)
-            .offset(offset)
-            .color(color)
-    }
-}
-
-/// Create a `DrawParam` from a location, rotation, offset, scale and color
-impl<P, V> From<(P, f32, P, V, Color)> for DrawParam
-where
-    P: Into<mint::Point2<f32>>,
-    V: Into<mint::Vector2<f32>>,
-{
-    fn from((location, rotation, offset, scale, color): (P, f32, P, V, Color)) -> Self {
-        DrawParam::new()
-            .dest(location)
-            .rotation(rotation)
-            .offset(offset)
-            .scale(scale)
-            .color(color)
+    fn from(location: P) -> Self {
+        DrawParam::new().dest(location)
     }
 }
 


### PR DESCRIPTION
Addresses https://github.com/ggez/ggez/issues/1023.

Also found a missing font error in the sounds example (again, a typo in the commit message... really gotta start paying more attention there...).

In the end, only `From<(P,)>` was used widely and it was easily (and more readably) replaced with the new `From<P>` implementation. The other tuple implementations were used 2 times in total, with some completely unused.