### PR TITLE
made sure the window has a minimum width and height of 1 to avoid wgpu panics

### DIFF
--- a/src/conf.rs
+++ b/src/conf.rs
@@ -73,11 +73,13 @@ pub struct WindowMode {
     /// Whether or not to show window decorations
     #[default = false]
     pub borderless: bool,
-    /// Minimum width for resizable windows; 0 means no limit
-    #[default = 0.0]
+    /// Minimum width for resizable windows; 1 is the technical minimum,
+    /// as wgpu will panic on a width of 0.
+    #[default = 1.0]
     pub min_width: f32,
-    /// Minimum height for resizable windows; 0 means no limit
-    #[default = 0.0]
+    /// Minimum height for resizable windows; 1 is the technical minimum,
+    /// as wgpu will panic on a height of 0.
+    #[default = 1.0]
     pub min_height: f32,
     /// Maximum width for resizable windows; 0 means no limit
     #[default = 0.0]
@@ -329,7 +331,6 @@ impl From<NumSamples> for u8 {
 ///     window_mode: WindowMode::default(),
 ///     window_setup: WindowSetup::default(),
 ///     backend: Backend::default(),
-///     modules: ModuleConf::default(),
 /// }
 /// # , Conf::default()); }
 /// ```

--- a/src/conf.rs
+++ b/src/conf.rs
@@ -110,8 +110,12 @@ impl WindowMode {
     /// Set default window size, or screen resolution in true fullscreen mode.
     #[must_use]
     pub fn dimensions(mut self, width: f32, height: f32) -> Self {
-        self.width = width;
-        self.height = height;
+        if width >= 1.0 {
+            self.width = width;
+        }
+        if height >= 1.0 {
+            self.height = height;
+        }
         self
     }
 
@@ -137,10 +141,15 @@ impl WindowMode {
     }
 
     /// Set minimum window dimensions for windowed mode.
+    /// Minimum dimensions will always be >= 1.
     #[must_use]
     pub fn min_dimensions(mut self, width: f32, height: f32) -> Self {
-        self.min_width = width;
-        self.min_height = height;
+        if width >= 1.0 {
+            self.min_width = width;
+        }
+        if height >= 1.0 {
+            self.min_height = height;
+        }
         self
     }
 

--- a/src/graphics/context.rs
+++ b/src/graphics/context.rs
@@ -672,6 +672,8 @@ impl GraphicsContext {
         }
 
         let size = window.inner_size();
+        assert!(size.width > 0 && size.height > 0);
+
         self.wgpu.surface.configure(
             &self.wgpu.device,
             &wgpu::SurfaceConfiguration {

--- a/src/graphics/context.rs
+++ b/src/graphics/context.rs
@@ -111,12 +111,12 @@ impl GraphicsContext {
             Backend::BrowserWebGpu => wgpu::Backends::BROWSER_WEBGPU,
         });
 
+        let physical_size =
+            dpi::PhysicalSize::<f64>::from((conf.window_mode.width, conf.window_mode.height));
+        assert!(physical_size.width >= 1.0 && physical_size.height >= 1.0); // wgpu needs surfaces > 0
         let mut window_builder = winit::window::WindowBuilder::new()
             .with_title(conf.window_setup.title.clone())
-            .with_inner_size(dpi::PhysicalSize::<f64>::from((
-                conf.window_mode.width,
-                conf.window_mode.height,
-            )))
+            .with_inner_size(physical_size)
             .with_resizable(conf.window_mode.resizable)
             .with_visible(conf.window_mode.visible);
 
@@ -607,13 +607,16 @@ impl GraphicsContext {
         let window = &mut self.window;
 
         // TODO LATER: find out if single-dimension constraints are possible?
-        let min_dimensions = if mode.min_width > 0.0 && mode.min_height > 0.0 {
+        let min_dimensions = if mode.min_width >= 1.0 && mode.min_height >= 1.0 {
             Some(dpi::PhysicalSize {
                 width: f64::from(mode.min_width),
                 height: f64::from(mode.min_height),
             })
         } else {
-            None
+            return Err(GameError::WindowError(format!(
+                "window min_width and min_height need to be at least 1; actual values: {}, {}",
+                mode.min_width, mode.min_height
+            )));
         };
         window.set_min_inner_size(min_dimensions);
 
@@ -632,10 +635,17 @@ impl GraphicsContext {
             FullscreenType::Windowed => {
                 window.set_fullscreen(None);
                 window.set_decorations(!mode.borderless);
-                window.set_inner_size(dpi::PhysicalSize {
-                    width: f64::from(mode.width),
-                    height: f64::from(mode.height),
-                });
+                if mode.width >= 1.0 && mode.height >= 1.0 {
+                    window.set_inner_size(dpi::PhysicalSize {
+                        width: f64::from(mode.width),
+                        height: f64::from(mode.height),
+                    });
+                } else {
+                    return Err(GameError::WindowError(format!(
+                        "window width and height need to be at least 1; actual values: {}, {}",
+                        mode.width, mode.height
+                    )));
+                }
                 window.set_resizable(mode.resizable);
                 window.set_maximized(mode.maximized);
             }


### PR DESCRIPTION
If you resize any resizable window to a height of zero or less (which is currently possible) then the program will just crash, as wgpu needs surfaces that have an area > 0, so we need to avoid these.